### PR TITLE
Gnome45

### DIFF
--- a/srcpkgs/gnome-connections/template
+++ b/srcpkgs/gnome-connections/template
@@ -6,7 +6,7 @@ build_style=meson
 build_helper="gir"
 hostmakedepends="pkg-config gettext itstool vala desktop-file-utils glib-devel"
 makedepends="gtk+3-devel libhandy1-devel gtk-vnc-devel libgcrypt-devel
- gnutls-devel libsasl-devel libsecret-devel freerdp-devel"
+ gnutls-devel libsasl-devel libsecret-devel freerdp-devel fuse3-devel"
 short_desc="Remote desktop client for the GNOME desktop environment"
 maintainer="oreo6391 <oreo6391@gmail.com>"
 license="GPL-3.0-or-later"

--- a/srcpkgs/mutter/template
+++ b/srcpkgs/mutter/template
@@ -12,7 +12,7 @@ hostmakedepends="gettext glib-devel pkg-config zenity wayland-devel xorg-server
 makedepends="elogind-devel glib-devel gnome-desktop-devel graphene-devel
  json-glib-devel libglib-devel libSM-devel libXtst-devel libcanberra-devel
  libinput-devel MesaLib-devel pipewire-devel startup-notification-devel gtk4-devel
- wayland-protocols gnome-settings-daemon-devel libgudev-devel libwacom-devel libei"
+ wayland-protocols gnome-settings-daemon-devel libgudev-devel libwacom-devel libei-devel"
 depends="gsettings-desktop-schemas desktop-file-utils"
 short_desc="Wayland display server, X11 window manager and compositor library"
 maintainer="Michal Vasilek <michal@vasilek.cz>"

--- a/srcpkgs/pango/template
+++ b/srcpkgs/pango/template
@@ -1,6 +1,6 @@
 # Template file for 'pango'
 pkgname=pango
-version=1.50.14
+version=1.51.0
 revision=1
 build_style=meson
 build_helper=gir
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://www.pango.org/"
 changelog="https://gitlab.gnome.org/GNOME/pango/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/pango/${version%.*}/pango-${version}.tar.xz"
-checksum=1d67f205bfc318c27a29cfdfb6828568df566795df0cb51d2189cde7f2d581e8
+checksum=74efc109ae6f903bbe6af77eaa2ac6094b8ee245a2e23f132a7a8f0862d1a9f5
 make_check=no  # doesn't pass its own tests
 
 # Package build options

--- a/srcpkgs/zenity/template
+++ b/srcpkgs/zenity/template
@@ -1,18 +1,18 @@
 # Template file for 'zenity'
 pkgname=zenity
-version=3.44.1
+version=3.99.2
 revision=1
 build_style=meson
 configure_args="-Dwebkitgtk=$(vopt_if webkit true false)"
 hostmakedepends="gettext itstool perl pkg-config gtk-update-icon-cache"
-makedepends="gtk+3-devel libglib-devel libnotify-devel $(vopt_if webkit libwebkit2gtk41-devel)"
+makedepends="gtk+3-devel libglib-devel libnotify-devel $(vopt_if webkit libwebkit2gtk41-devel) libadwaita-devel libwebkitgtk60-devel help2man"
 short_desc="Display GNOME dialogs from the command line"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://help.gnome.org/users/zenity/"
 changelog="https://gitlab.gnome.org/GNOME/zenity/-/raw/zenity-3-44/NEWS"
 distfiles="${GNOME_SITE}/zenity/${version%.*}/zenity-${version}.tar.xz"
-checksum=d65400aec965411f4c0b3d8e0e0dac54be55d807a29279697537da2dfee93eaa
+checksum=a19478906b988b4f367e5ea63a5921e4f98cb8255bba05eb5cad8b5a18a4168f
 
 build_options="webkit"
 build_options_default="webkit"


### PR DESCRIPTION
#### Testing the changes
- I tested the changes in this PR: **briefly**

#### Local build testing
- I built this PR locally for my native architecture, (x86_64, libc)

## Copy of previous comment
I was able to build with the following changes. Hopefully they help someone. 
- gnome-connections required `fuse3-devel` to build. 
- Mutter required averyterrel's change to `libei-devel`
- I updated `pango` to 1.51.0
- I updated `zenity` to 3.99.2

srcpkgs/gnome-connections/template
```diff
 makedepends="gtk+3-devel libhandy1-devel gtk-vnc-devel libgcrypt-devel
- gnutls-devel libsasl-devel libsecret-devel freerdp-devel"
+ gnutls-devel libsasl-devel libsecret-devel freerdp-devel fuse3-devel"
```

srcpkgs/mutter/template
```diff
 makedepends="elogind-devel glib-devel gnome-desktop-devel graphene-devel
  json-glib-devel libglib-devel libSM-devel libXtst-devel libcanberra-devel
  libinput-devel MesaLib-devel pipewire-devel startup-notification-devel gtk4-devel
- wayland-protocols gnome-settings-daemon-devel libgudev-devel libwacom-devel libei"
+ wayland-protocols gnome-settings-daemon-devel libgudev-devel libwacom-devel libei-devel"
```

srcpkgs/pango/template
```diff
 # Template file for 'pango'
 pkgname=pango
-version=1.50.14
+version=1.51.0
 revision=1
 build_style=meson
 build_helper=gir
@@ -14,7 +14,7 @@ license="LGPL-2.1-or-later"
 homepage="https://www.pango.org/"
 changelog="https://gitlab.gnome.org/GNOME/pango/-/raw/main/NEWS"
 distfiles="${GNOME_SITE}/pango/${version%.*}/pango-${version}.tar.xz"
-checksum=1d67f205bfc318c27a29cfdfb6828568df566795df0cb51d2189cde7f2d581e8
+checksum=74efc109ae6f903bbe6af77eaa2ac6094b8ee245a2e23f132a7a8f0862d1a9f5
 make_check=no  # doesn't pass its own tests
``` 

srcpkgs/zenity/template
```diff
 pkgname=zenity
-version=3.44.1
+version=3.99.2
 revision=1
 build_style=meson
 configure_args="-Dwebkitgtk=$(vopt_if webkit true false)"
 hostmakedepends="gettext itstool perl pkg-config gtk-update-icon-cache"
-makedepends="gtk+3-devel libglib-devel libnotify-devel $(vopt_if webkit libwebkit2gtk41-devel)"
+makedepends="gtk+3-devel libglib-devel libnotify-devel $(vopt_if webkit libwebkit2gtk41-devel) libadwaita-devel libwebkitgtk60-devel help2man"
 short_desc="Display GNOME dialogs from the command line"
 maintainer="Enno Boland <gottox@voidlinux.org>"
 license="LGPL-2.0-or-later"
 homepage="https://help.gnome.org/users/zenity/"
 changelog="https://gitlab.gnome.org/GNOME/zenity/-/raw/zenity-3-44/NEWS"
 distfiles="${GNOME_SITE}/zenity/${version%.*}/zenity-${version}.tar.xz"
-checksum=d65400aec965411f4c0b3d8e0e0dac54be55d807a29279697537da2dfee93eaa
+checksum=a19478906b988b4f367e5ea63a5921e4f98cb8255bba05eb5cad8b5a18a4168f
```

I also installed the gnome 45 package on my host system, and it seems to be stable so far. I will update with any further changes I make to increase stability. 